### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "dependencies/spl-class-loader"]
 	path = dependencies/spl-class-loader
-	url = git@github.com:hailocab/php-spl-class-loader.git
+	url = git://github.com/hailocab/php-spl-class-loader.git
 [submodule "dependencies/react-php"]
 	path = dependencies/react-php
 	url = git://github.com/davegardnerisme/react.git


### PR DESCRIPTION
before you needed to have ssh public key on github to pull the spl-class-loader depancy if you pull this repo with https or git repo then you may not have ssh keys.