### PR TITLE
fix logic bug

### DIFF
--- a/src/nsqphp/Connection/Connection.php
+++ b/src/nsqphp/Connection/Connection.php
@@ -145,7 +145,8 @@ class Connection implements ConnectionInterface
         $null = NULL;
         $read = array($socket = $this->getSocket());
         $buffer = $data = '';
-        while (strlen($data) < $len) {
+        $originLen = $len;
+        while (strlen($data) < $originLen) {
             $readable = stream_select($read, $null, $null, $this->readWriteTimeoutSec, $this->readWriteTimeoutUsec);
             if ($readable > 0) {
                 $buffer = @stream_socket_recvfrom($socket, $len);


### PR DESCRIPTION
while try to read buffer stream from nsq server,The client is interrupted because the number of bytes in the loop is less than the expected number of bytes.