### PR TITLE
Feature nslookup bugfix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "luoxiaojun1992/nsqphp",
+    "name": "davegardnerisme/nsqphp",
     "description": "PHP client for NSQ",
     "type": "library",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "davegardnerisme/nsqphp",
+    "name": "luoxiaojun1992/nsqphp",
     "description": "PHP client for NSQ",
     "type": "library",
     "keywords": [

--- a/src/nsqphp/Lookup/Nsqlookupd.php
+++ b/src/nsqphp/Lookup/Nsqlookupd.php
@@ -98,6 +98,9 @@ class Nsqlookupd implements LookupInterface
             }*/
             
             $producers = isset($r['data'], $r['data']['producers']) ? $r['data']['producers'] : array();
+            if (count($producers) < 1) {
+                $producers = isset($r['producers']) ? $r['producers'] : array();
+            }
             foreach ($producers as $prod) {
                 if (isset($prod['address'])) {
                     $address = $prod['address'];


### PR DESCRIPTION
Hi, because the nsqlookup of version1.0.0 returns the following message without data element, my sdk dosen't work.
```php
array(2) {
  'channels' =>
  array(0) {
  }
  'producers' =>
  array(1) {
    [0] =>
    array(6) {
      'remote_address' =>
      string(15) "127.0.0.1:65494"
      'hostname' =>
      string(26) "luoxiaojundeMac-mini.local"
      'broadcast_address' =>
      string(26) "luoxiaojundeMac-mini.local"
      'tcp_port' =>
      int(4150)
      'http_port' =>
      int(4151)
      'version' =>
      string(12) "1.0.0-compat"
    }
  }
}
```